### PR TITLE
Expose Docker's volume API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,13 +11,23 @@ Mount
 :::::
 
 This mounts paths as docker volumes.
-The path used inside the container is the same as the path outside the container.
 Multiple paths may be passed.
 The last path must be terminated with two slashes -- before the image name.
+You can either pass a path directly (without colons) and the path used inside the container is the same as the path outside the container.
+For example:
 
 ::
 
     rocker --oyr-mount ~/.vimrc ~/.bashrc -- ubuntu:18.04
+
+Or use the colon syntax for ``Docker volumes <https://docs.docker.com/storage/volumes/#choose-the--v-or---mount-flag>``_.
+This includes the ability to specify comma separated options, such as ``ro`` for readonly.
+This syntax supports the use of named volumes, which must first be created (for example, with ``docker volume create``)
+
+::
+
+    # docker volume create my_volume
+    rocker --oyr-mount ~/.bashrc:/root/.bashrc ~/.vimrc:/root/.vimrc:ro my_volume:/root/my_volume -- ubuntu:18.04
 
 Colcon
 ::::::

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ For example:
 
     rocker --oyr-mount ~/.vimrc ~/.bashrc -- ubuntu:18.04
 
-Or use the colon syntax for ``Docker volumes <https://docs.docker.com/storage/volumes/#choose-the--v-or---mount-flag>``_.
+Or use the colon syntax for `Docker volumes <https://docs.docker.com/storage/volumes/#choose-the--v-or---mount-flag>`_.
 This includes the ability to specify comma separated options, such as ``ro`` for readonly.
 This syntax supports the use of named volumes, which must first be created (for example, with ``docker volume create``)
 

--- a/off_your_rocker/mount.py
+++ b/off_your_rocker/mount.py
@@ -26,7 +26,20 @@ class Mount(RockerExtension):
         args = ['']
         for mount in cli_args['oyr_mount']:
             mount = os.path.abspath(mount)
-            args.append('-v {0}:{0}'.format(mount))
+            mount_args = mount.split(':')
+            if len(mount_args) == 1:
+                src_and_dst, = mount_args
+                arg = '{0}:{0}'.format(src_and_dst)
+            elif len(mount_args) == 2:
+                src, dst = mount_args
+                arg = '{src}:{dst}'.format(src=src, dst=dst)
+            elif len(mount_args) == 3:
+                src, dst, permissions = mount_args
+                arg = '{src}:{dst}:{permissions}'.format(
+                    src=src, dst=dst, permissions=permissions)
+            else:
+                raise ValueError("Invalid mount string: '{0}'".format(mount))
+            args.append('-v {0}'.format(arg))
         return ' '.join(args)
 
     @staticmethod

--- a/off_your_rocker/mount.py
+++ b/off_your_rocker/mount.py
@@ -25,11 +25,10 @@ class Mount(RockerExtension):
     def get_docker_args(self, cli_args):
         args = ['']
         for mount in cli_args['oyr_mount']:
-            mount = os.path.abspath(mount)
             mount_args = mount.split(':')
             if len(mount_args) == 1:
                 src_and_dst, = mount_args
-                arg = '{0}:{0}'.format(src_and_dst)
+                arg = '{0}:{0}'.format(os.path.abspath(src_and_dst))
             elif len(mount_args) == 2:
                 src, dst = mount_args
                 arg = '{src}:{dst}'.format(src=src, dst=dst)


### PR DESCRIPTION
This PR exposes the [Docker Volume API](https://docs.docker.com/storage/volumes/#choose-the--v-or---mount-flag) so that you can 
* specify different paths for mounting a directory on your computer and in the container,
* use options with the mount, such as `ro` for readonly, and
* use existing volumes (similar to #4).