### PR TITLE
Feature/default arguments

### DIFF
--- a/off_your_rocker/capabilities.py
+++ b/off_your_rocker/capabilities.py
@@ -29,7 +29,7 @@ class CapAdd(RockerExtension):
         return ' '.join(args)
 
     @staticmethod
-    def register_arguments(parser):
+    def register_arguments(parser, defaults):
         parser.add_argument('--oyr-cap-add',
             metavar='CAPABILITY',
             type=str,
@@ -64,7 +64,7 @@ class CapDrop(RockerExtension):
         return ' '.join(args)
 
     @staticmethod
-    def register_arguments(parser):
+    def register_arguments(parser, defaults):
         parser.add_argument('--oyr-cap-drop',
             metavar='CAPABILITY',
             type=str,

--- a/off_your_rocker/colcon.py
+++ b/off_your_rocker/colcon.py
@@ -30,7 +30,7 @@ class Colcon(RockerExtension):
         return ''
 
     @staticmethod
-    def register_arguments(parser):
+    def register_arguments(parser, defaults):
         parser.add_argument('--oyr-colcon',
             action='store_true',
             help='install colcon with some useful extensions')

--- a/off_your_rocker/mount.py
+++ b/off_your_rocker/mount.py
@@ -30,7 +30,7 @@ class Mount(RockerExtension):
         return ' '.join(args)
 
     @staticmethod
-    def register_arguments(parser):
+    def register_arguments(parser, defaults):
         parser.add_argument('--oyr-mount',
             metavar='PATH',
             type=str,

--- a/off_your_rocker/run_arg.py
+++ b/off_your_rocker/run_arg.py
@@ -29,7 +29,7 @@ class RunArg(RockerExtension):
         return ' '.join(args)
 
     @staticmethod
-    def register_arguments(parser):
+    def register_arguments(parser, defaults):
         parser.add_argument('--oyr-run-arg',
             metavar='DOCKER_RUN_ARG',
             type=str,

--- a/off_your_rocker/spacenav.py
+++ b/off_your_rocker/spacenav.py
@@ -30,7 +30,7 @@ class SpaceNav(RockerExtension):
         return ''
 
     @staticmethod
-    def register_arguments(parser):
+    def register_arguments(parser, defaults):
         parser.add_argument('--oyr-spacenav',
             action='store_true',
             help='enable 3Dconnexion SpaceNavigator in container')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as fin:
 
 setup(
     name='off-your-rocker',
-    version='0.1.0',
+    version='0.1.1',
     packages=['off_your_rocker'],
     package_data={'off_your_rocker': ['templates/*.em']},
     author='Shane Loretz',


### PR DESCRIPTION
When running rocker with oyr installed I get warning messages about registering default arguments:
```bash
$ rocker
Extension oyr_cap_add doesn't support default arguments. Please extend it.
Extension oyr_cap_drop doesn't support default arguments. Please extend it.
Extension oyr_colcon doesn't support default arguments. Please extend it.
Extension oyr_mount doesn't support default arguments. Please extend it.
Extension oyr_run_arg doesn't support default arguments. Please extend it.
Extension oyr_spacenav doesn't support default arguments. Please extend it.
```

This pr adds a defaults argument to the register_arguments function to remove those warnings and bumps the package version number.